### PR TITLE
Add assertions to mark and unmark methods

### DIFF
--- a/src/main/java/univus/Parser.java
+++ b/src/main/java/univus/Parser.java
@@ -33,6 +33,7 @@ public class Parser {
                 throw new UnivusException("Already Marked!");
             } else {
                 task.mark();
+                assert task.isDone() == true;
                 responses.append("Nice! I've marked this task as done:\n");
                 responses.append("\t" + task.toString() + "\n");
             }
@@ -58,6 +59,7 @@ public class Parser {
                 throw new UnivusException("Already Unmarked!");
             } else {
                 task.unMark();
+                assert task.isDone() == false;
                 responses.append("OK, I've marked this task as not done yet:\n");
                 responses.append("\t" + task.toString() + "\n");
             }


### PR DESCRIPTION
The code for marking and unmarking tasks lacks explicit checks to enure that the tasks are correctly marked or unmarked.

The mark and unmark methods have no ability to catch potential issues during development.

Assert statements are useful to validate the expected state of tasks after marking or unmarking.

Let's add assert statements to verify the correctness of task marking and unmarking.

The assert statements serve as a form of self-documentation and provide a safety net for identifying and addressing potential issues related to task state.